### PR TITLE
fix(redis-store): correct key lookup for has check

### DIFF
--- a/api/src/store/redis-store.js
+++ b/api/src/store/redis-store.js
@@ -20,7 +20,7 @@ export default class RedisStore extends Store {
     async _has(key) {
         await this.#connected;
 
-        return this.#client.hExists(key);
+        return !!(await this.#client.exists(this.#keyOf(key)));
     }
 
     async _get(key) {


### PR DESCRIPTION
## Summary
- ensure RedisStore uses `EXISTS` with prefixed key in `_has`

## Testing
- `pnpm test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68a26804071c83269ac10dd3cf7008bc